### PR TITLE
chore(deps): minor update @jest/types to v27.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -860,9 +860,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
-      "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "12.20.2"
   },
   "devDependencies": {
-    "@jest/types": "27.0.6",
+    "@jest/types": "27.4.2",
     "@tsconfig/node12": "1.0.9",
     "@types/jest": "27.0.3",
     "@types/node": "12.20.15",


### PR DESCRIPTION
This PR updates these packages:

|Package|Level|Current version|New version|
|---|---|---|---|
|[@jest/types](https://www.npmjs.com/package/@jest/types)|minor|`27.0.6`|`27.4.2`|

<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.27.0.beta",
  "packages": [
    {
      "name": "@jest/types",
      "currentVersion": "27.0.6",
      "newVersion": "27.4.2",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.27.0.beta