### PR TITLE
chore(deps): minor update @types/jest to v27.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,9 +1021,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
-      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
       "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
@@ -3549,15 +3549,15 @@
       }
     },
     "jest-diff": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.2.tgz",
-      "integrity": "sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==",
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.6.tgz",
+      "integrity": "sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.4.0",
         "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.2"
+        "pretty-format": "^27.4.6"
       }
     },
     "jest-docblock": {
@@ -4862,30 +4862,16 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
-      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "27.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
-          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@jest/types": "27.0.6",
     "@tsconfig/node12": "1.0.9",
-    "@types/jest": "27.0.3",
+    "@types/jest": "27.4.0",
     "@types/node": "12.20.15",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Level|Current version|New version|
|---|---|---|---|
|[@types/jest](https://www.npmjs.com/package/@types/jest)|minor|`27.0.3`|`27.4.0`|

<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.27.0.beta",
  "packages": [
    {
      "name": "@types/jest",
      "currentVersion": "27.0.3",
      "newVersion": "27.4.0",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.27.0.beta