### PR TITLE
chore(deps): patch update lint-staged to v12.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4314,9 +4314,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.2.1.tgz",
-      "integrity": "sha512-VCVcA9C2Vt5HHxSR4EZVZFJcQRJH984CGBeY+cJ/xed4mBd+JidbM/xbKcCq5ASaygAV0iITtdsCTnID7h/1OQ==",
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.2.2.tgz",
+      "integrity": "sha512-bcHEoM1M/f+K1BYdHcEuIn8K+zMOSJR3mkny6PAuQiTgcSUcRbUWaUD6porAYypxF4k1vYZZ2HutZt1p94Z1jQ==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-promise": "5.2.0",
     "husky": "7.0.4",
     "jest": "27.0.6",
-    "lint-staged": "12.2.1",
+    "lint-staged": "12.2.2",
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.4.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Level|Current version|New version|
|---|---|---|---|
|[lint-staged](https://www.npmjs.com/package/lint-staged)|patch|`12.2.1`|`12.2.2`|

<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.27.0.beta",
  "packages": [
    {
      "name": "lint-staged",
      "currentVersion": "12.2.1",
      "newVersion": "12.2.2",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.27.0.beta