### PR TITLE
chore(deps): patch update typescript to v4.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5485,9 +5485,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.4.0",
-    "typescript": "4.5.4"
+    "typescript": "4.5.5"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR updates these packages:

|Package|Level|Current version|New version|
|---|---|---|---|
|[typescript](https://www.npmjs.com/package/typescript)|patch|`4.5.4`|`4.5.5`|

<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.27.0.beta",
  "packages": [
    {
      "name": "typescript",
      "currentVersion": "4.5.4",
      "newVersion": "4.5.5",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.27.0.beta