### PR TITLE
chore(deps): major update @types/node to v17.0.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,9 +1153,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+      "version": "17.0.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
+      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@jest/types": "27.4.2",
     "@tsconfig/node12": "1.0.9",
     "@types/jest": "27.4.0",
-    "@types/node": "12.20.15",
+    "@types/node": "17.0.19",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",
     "eslint-config-standard-with-typescript": "21.0.1",


### PR DESCRIPTION
This PR updates these packages:

|Package|Repository|Level|Current version|New version|
|---|---|---|---|---|
|[@types/node](https://www.npmjs.com/package/@types/node)|[DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)|major|`12.20.15`|`17.0.19`|

<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.34.0",
  "packages": [
    {
      "name": "@types/node",
      "currentVersion": "12.20.15",
      "newVersion": "17.0.19",
      "level": "major"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.34.0