### PR TITLE
chore(deps): patch update @types/jest to v27.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,12 +1131,12 @@
       }
     },
     "@types/jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
-      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
+      "version": "27.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
       "dev": true,
       "requires": {
-        "jest-diff": "^27.0.0",
+        "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
     },
@@ -3145,9 +3145,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-6.0.0.tgz",
+      "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
       "dev": true
     },
     "iconv-lite": {
@@ -3718,18 +3718,6 @@
             "react-is": "^17.0.1"
           }
         }
-      }
-    },
-    "jest-diff": {
-      "version": "27.4.6",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.6.tgz",
-      "integrity": "sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.4.0",
-        "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.6"
       }
     },
     "jest-docblock": {
@@ -5350,9 +5338,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.4.6",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
-      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@jest/types": "27.4.2",
     "@tsconfig/node12": "1.0.9",
-    "@types/jest": "27.4.0",
+    "@types/jest": "27.4.1",
     "@types/node": "12.20.15",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",
@@ -27,7 +27,7 @@
     "eslint-plugin-jest": "25.3.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
-    "husky": "7.0.4",
+    "husky": "^6.0.0",
     "jest": "27.4.7",
     "lint-staged": "12.3.4",
     "rimraf": "3.0.2",


### PR DESCRIPTION
This PR updates these packages:

|Package|Repository|Dependency type|Level|Version|
|---|---|---|---|---|
|[@types/jest](https://www.npmjs.com/package/@types/jest)|[DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)|devDependencies|patch|[`27.4.0`](https://www.npmjs.com/package/@types/jest/v/27.4.0) -> [`27.4.1`](https://www.npmjs.com/package/@types/jest/v/27.4.1) ([diff](https://renovatebot.com/diffs/npm/@types/jest/27.4.0/27.4.1))|

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.39.0",
  "packages": [
    {
      "name": "@types/jest",
      "currentVersion": "27.4.0",
      "newVersion": "27.4.1",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.39.0