### PR TITLE
chore(deps): patch update lint-staged to v12.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1960,9 +1960,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.0.tgz",
-          "integrity": "sha512-7x54QnN21P+XL/v8SuNKvfgsUre6PXpN7mc77N3HlZv+f1SBRGmjxtOud2Z6FZ8DmdkD/IdjCaf9XXbnqmTZGQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
           "dev": true,
           "requires": {
             "eastasianwidth": "^0.2.0",
@@ -4780,9 +4780,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.4.tgz",
-      "integrity": "sha512-yv/iK4WwZ7/v0GtVkNb3R82pdL9M+ScpIbJLJNyCXkJ1FGaXvRCOg/SeL59SZtPpqZhE7BD6kPKFLIDUhDx2/w==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.5.tgz",
+      "integrity": "sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-promise": "5.2.0",
     "husky": "7.0.4",
     "jest": "27.4.7",
-    "lint-staged": "12.3.4",
+    "lint-staged": "12.3.5",
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.5.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Version|
|---|---|---|---|
|[lint-staged](https://www.npmjs.com/package/lint-staged)|devDependencies|patch|[`12.3.4`](https://www.npmjs.com/package/lint-staged/v/12.3.4) -> [`12.3.5`](https://www.npmjs.com/package/lint-staged/v/12.3.5) ([diff](https://renovatebot.com/diffs/npm/lint-staged/12.3.4/12.3.5))|

## Release notes

- [v12.3.5](https://github.com/okonet/lint-staged/releases/tag/v12.3.5)
- [v12.3.4](https://github.com/okonet/lint-staged/releases/tag/v12.3.4)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.43.3",
  "packages": [
    {
      "name": "lint-staged",
      "currentVersion": "12.3.4",
      "newVersion": "12.3.5",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.43.3