### PR TITLE
chore(deps): minor update ts-node to v10.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5874,9 +5874,9 @@
       }
     },
     "ts-node": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint-staged": "12.3.4",
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
-    "ts-node": "10.5.0",
+    "ts-node": "10.7.0",
     "typescript": "4.5.5"
   },
   "license": "MIT"


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Version|
|---|---|---|---|
|[ts-node](https://www.npmjs.com/package/ts-node)|devDependencies|minor|[`10.5.0`](https://www.npmjs.com/package/ts-node/v/10.5.0) -> [`10.7.0`](https://www.npmjs.com/package/ts-node/v/10.7.0) ([diff](https://renovatebot.com/diffs/npm/ts-node/10.5.0/10.7.0))|

## Release notes

- [v10.7.0](https://github.com/TypeStrong/ts-node/releases/tag/v10.7.0)
- [v10.6.0](https://github.com/TypeStrong/ts-node/releases/tag/v10.6.0)
- [v10.5.0](https://github.com/TypeStrong/ts-node/releases/tag/v10.5.0)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.43.3",
  "packages": [
    {
      "name": "ts-node",
      "currentVersion": "10.5.0",
      "newVersion": "10.7.0",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.43.3