### PR TITLE
chore(deps): minor update typescript to v4.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5960,9 +5960,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.5.0",
-    "typescript": "4.5.5"
+    "typescript": "4.6.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Version|
|---|---|---|---|
|[typescript](https://www.npmjs.com/package/typescript)|devDependencies|minor|[`4.5.5`](https://www.npmjs.com/package/typescript/v/4.5.5) -> [`4.6.2`](https://www.npmjs.com/package/typescript/v/4.6.2) ([diff](https://renovatebot.com/diffs/npm/typescript/4.5.5/4.6.2))|

## Release notes

- [v4.6.2](https://github.com/microsoft/TypeScript/releases/tag/v4.6.2)
- [v4.5.5](https://github.com/microsoft/TypeScript/releases/tag/v4.5.5)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.43.3",
  "packages": [
    {
      "name": "typescript",
      "currentVersion": "4.5.5",
      "newVersion": "4.6.2",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.43.3