### PR TITLE
chore(deps): patch update lint-staged to v12.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4768,9 +4768,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "12.3.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.5.tgz",
-      "integrity": "sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==",
+      "version": "12.3.6",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.6.tgz",
+      "integrity": "sha512-tVNyl/HsAnplKh4oaoRNzyZLm0PE/6VaBUXvd/gA9zhYCC/+ivZwiwpoT6jOxcLzuIOjP19wW+mfOi7/Bw4c1A==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",
@@ -4783,6 +4783,7 @@
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
         "object-inspect": "^1.12.0",
+        "pidtree": "^0.5.0",
         "string-argv": "^0.3.1",
         "supports-color": "^9.2.1",
         "yaml": "^1.10.2"
@@ -4806,9 +4807,9 @@
       }
     },
     "listr2": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.4.tgz",
-      "integrity": "sha512-vJOm5KD6uZXjSsrwajr+mNacIjf87gWvlBEltPWLbTkslUscWAzquyK4xfe9Zd4RDgO5nnwFyV06FC+uVR+5mg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
@@ -4816,7 +4817,7 @@
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.4",
+        "rxjs": "^7.5.5",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -5265,6 +5266,12 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pidtree": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.5.0.tgz",
+      "integrity": "sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==",
+      "dev": true
+    },
     "pirates": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
@@ -5488,9 +5495,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-promise": "5.2.0",
     "husky": "7.0.4",
     "jest": "27.4.7",
-    "lint-staged": "12.3.5",
+    "lint-staged": "12.3.6",
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.7.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Version|
|---|---|---|---|
|[lint-staged](https://www.npmjs.com/package/lint-staged)|devDependencies|patch|[`12.3.5`](https://www.npmjs.com/package/lint-staged/v/12.3.5) -> [`12.3.6`](https://www.npmjs.com/package/lint-staged/v/12.3.6) ([diff](https://renovatebot.com/diffs/npm/lint-staged/12.3.5/12.3.6))|

## Release notes

- [v12.3.5](https://togithub.com/okonet/lint-staged/releases/tag/v12.3.5)
- [v12.3.6](https://togithub.com/okonet/lint-staged/releases/tag/v12.3.6)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.45.16",
  "packages": [
    {
      "name": "lint-staged",
      "currentVersion": "12.3.5",
      "newVersion": "12.3.6",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.45.16