### PR TITLE
chore(deps): patch update ts-jest to v27.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3271,15 +3271,6 @@
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "dev": true
     },
-    "is-ci": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^3.1.1"
-      }
-    },
     "is-core-module": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
@@ -4532,23 +4523,42 @@
       }
     },
     "jest-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
-      "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "is-ci": "^3.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
         "picomatch": "^2.2.3"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+          "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+          "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+          "dev": true
+        },
         "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
           "dev": true
         }
       }
@@ -5923,9 +5933,9 @@
       }
     },
     "ts-jest": {
-      "version": "27.1.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
-      "integrity": "sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==",
+      "version": "27.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.4.tgz",
+      "integrity": "sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -5939,13 +5949,10 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint-staged": "12.3.7",
     "node-mocks-http": "1.10.1",
     "rimraf": "3.0.2",
-    "ts-jest": "27.1.3",
+    "ts-jest": "27.1.4",
     "ts-node": "10.7.0",
     "typescript": "4.6.2"
   },


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[ts-jest](https://www.npmjs.com/package/ts-jest)|devDependencies|patch|[`27.1.3`](https://www.npmjs.com/package/ts-jest/v/27.1.3)|[`27.1.4`](https://www.npmjs.com/package/ts-jest/v/27.1.4)|

## Package diffs

- [GitHub](https://togithub.com/kulshekhar/ts-jest/compare/v27.1.3...v27.1.4)
- [npmfs](https://npmfs.com/compare/ts-jest/27.1.3/27.1.4)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/ts-jest/27.1.3/27.1.4)

## Release notes

- [v27.1.3](https://togithub.com/kulshekhar/ts-jest/releases/tag/v27.1.3)
- [v27.1.4](https://togithub.com/kulshekhar/ts-jest/releases/tag/v27.1.4)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.49.1",
  "packages": [
    {
      "name": "ts-jest",
      "currentVersion": "27.1.3",
      "newVersion": "27.1.4",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.49.1