### PR TITLE
chore(deps): patch update typescript to v4.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6046,9 +6046,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.7.0",
-    "typescript": "4.6.2"
+    "typescript": "4.6.3"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[typescript](https://www.npmjs.com/package/typescript)|devDependencies|patch|[`4.6.2`](https://www.npmjs.com/package/typescript/v/4.6.2)|[`4.6.3`](https://www.npmjs.com/package/typescript/v/4.6.3)|

## Package diffs

- [GitHub](https://togithub.com/Microsoft/TypeScript/compare/v4.6.2...v4.6.3)
- [npmfs](https://npmfs.com/compare/typescript/4.6.2/4.6.3)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/typescript/4.6.2/4.6.3)

## Release notes

- [v4.6.2](https://togithub.com/Microsoft/TypeScript/releases/tag/v4.6.2)
- [v4.6.3](https://togithub.com/Microsoft/TypeScript/releases/tag/v4.6.3)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.49.1",
  "packages": [
    {
      "name": "typescript",
      "currentVersion": "4.6.2",
      "newVersion": "4.6.3",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.49.1