### PR TITLE
chore(deps): minor update @jest/types to v27.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,9 +970,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
-      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "12.20.2"
   },
   "devDependencies": {
-    "@jest/types": "27.4.2",
+    "@jest/types": "27.5.1",
     "@tsconfig/node12": "1.0.9",
     "@types/jest": "27.4.1",
     "@types/node": "12.20.15",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[@jest/types](https://www.npmjs.com/package/@jest/types)|devDependencies|minor|[`27.4.2`](https://www.npmjs.com/package/@jest/types/v/27.4.2)|[`27.5.1`](https://www.npmjs.com/package/@jest/types/v/27.5.1)|

## Package diffs

- [GitHub](https://togithub.com/facebook/jest/compare/v27.4.2...v27.5.1)
- [npmfs](https://npmfs.com/compare/@jest/types/27.4.2/27.5.1)
- [Package Diff](https://diff.intrinsic.com/@jest/types/27.4.2/27.5.1)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/@jest/types/27.4.2/27.5.1)

## Release notes

- [v27.4.2](https://togithub.com/facebook/jest/releases/tag/v27.4.2)
- [v27.5.0](https://togithub.com/facebook/jest/releases/tag/v27.5.0)
- [v27.5.1](https://togithub.com/facebook/jest/releases/tag/v27.5.1)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.55.0",
  "packages": [
    {
      "name": "@jest/types",
      "currentVersion": "27.4.2",
      "newVersion": "27.5.1",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.55.0