### PR TITLE
chore(deps): major update @types/node to v17.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,9 +1153,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@jest/types": "27.4.2",
     "@tsconfig/node12": "1.0.9",
     "@types/jest": "27.4.1",
-    "@types/node": "12.20.15",
+    "@types/node": "17.0.23",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",
     "eslint-config-standard-with-typescript": "21.0.1",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[@types/node](https://www.npmjs.com/package/@types/node)|devDependencies|major|[`12.20.15`](https://www.npmjs.com/package/@types/node/v/12.20.15)|[`17.0.23`](https://www.npmjs.com/package/@types/node/v/17.0.23)|

## Package diffs

- [GitHub](https://togithub.com/DefinitelyTyped/DefinitelyTyped/compare/v12.20.15...v17.0.23)
- [npmfs](https://npmfs.com/compare/@types/node/12.20.15/17.0.23)
- [Package Diff](https://diff.intrinsic.com/@types/node/12.20.15/17.0.23)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/@types/node/12.20.15/17.0.23)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.55.0",
  "packages": [
    {
      "name": "@types/node",
      "currentVersion": "12.20.15",
      "newVersion": "17.0.23",
      "level": "major"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.55.0