### PR TITLE
chore(deps): minor update node-mocks-http to v1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2056,6 +2056,23 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -5135,12 +5152,13 @@
       "dev": true
     },
     "node-mocks-http": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.10.1.tgz",
-      "integrity": "sha512-/Nz83kiJ3z+vGqxmlDyv8+L1CJno+gH23DzG3oPH9dBSfMYa5IFVwPgZpXCB2kdiiIu/HoDpZ2BuLqQs7qjFLQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.11.0.tgz",
+      "integrity": "sha512-jS/WzSOcKbOeGrcgKbenZeNhxUNnP36Yw11+hL4TTxQXErGfqYZ+MaYNNvhaTiGIJlzNSqgQkk9j8dSu1YWSuw==",
       "dev": true,
       "requires": {
         "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
         "depd": "^1.1.0",
         "fresh": "^0.5.2",
         "merge-descriptors": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "husky": "7.0.4",
     "jest": "27.4.7",
     "lint-staged": "12.3.7",
-    "node-mocks-http": "1.10.1",
+    "node-mocks-http": "1.11.0",
     "rimraf": "3.0.2",
     "ts-jest": "27.1.3",
     "ts-node": "10.7.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[node-mocks-http](https://www.npmjs.com/package/node-mocks-http)|devDependencies|minor|[`1.10.1`](https://www.npmjs.com/package/node-mocks-http/v/1.10.1)|[`1.10.2`](https://www.npmjs.com/package/node-mocks-http/v/1.10.2)|

## Package diffs

- [GitHub](https://togithub.com/howardabrams/node-mocks-http/compare/v1.10.1...v1.10.2)
- [npmfs](https://npmfs.com/compare/node-mocks-http/1.10.1/1.10.2)
- [Package Diff](https://diff.intrinsic.com/node-mocks-http/1.10.1/1.10.2)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/node-mocks-http/1.10.1/1.10.2)

## Release notes

- [v1.10.1](https://togithub.com/howardabrams/node-mocks-http/releases/tag/v1.10.1)
- [v1.10.2](https://togithub.com/howardabrams/node-mocks-http/releases/tag/v1.10.2)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.56.0",
  "packages": [
    {
      "name": "node-mocks-http",
      "currentVersion": "1.10.1",
      "newVersion": "1.10.2",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.56.0