### PR TITLE
chore(deps): minor update undici to v5.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "undici": "5.7.0"
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@jest/types": "27.4.2",
@@ -7838,9 +7838,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.7.0.tgz",
-      "integrity": "sha512-ORgxwDkiPS+gK2VxE7iyVeR7JliVn5DqhZ4LgQqYLBXsuK+lwOEmnJ66dhvlpLM0tC3fC7eYF1Bti2frbw2eAA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
+      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
       "engines": {
         "node": ">=12.18"
       }
@@ -14031,9 +14031,9 @@
       }
     },
     "undici": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.7.0.tgz",
-      "integrity": "sha512-ORgxwDkiPS+gK2VxE7iyVeR7JliVn5DqhZ4LgQqYLBXsuK+lwOEmnJ66dhvlpLM0tC3fC7eYF1Bti2frbw2eAA=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
+      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "16.11.1"
   },
   "dependencies": {
-    "undici": "5.7.0"
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@jest/types": "27.4.2",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[undici](https://www.npmjs.com/package/undici)|dependencies|minor|[`5.7.0`](https://www.npmjs.com/package/undici/v/5.7.0)|[`5.8.0`](https://www.npmjs.com/package/undici/v/5.8.0)|

## Package diffs

- [GitHub](https://togithub.com/nodejs/undici/compare/v5.7.0...v5.8.0)
- [npmfs](https://npmfs.com/compare/undici/5.7.0/5.8.0)
- [Package Diff](https://diff.intrinsic.com/undici/5.7.0/5.8.0)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/undici/5.7.0/5.8.0)

## Release notes

- [v5.7.0](https://togithub.com/nodejs/undici/releases/tag/v5.7.0)
- [v5.8.0](https://togithub.com/nodejs/undici/releases/tag/v5.8.0)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "1.2.26",
  "packages": [
    {
      "name": "undici",
      "currentVersion": "5.7.0",
      "newVersion": "5.8.0",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v1.2.26