### PR TITLE
chore(deps): major update husky to v8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-jest": "26.5.3",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-promise": "5.2.0",
-        "husky": "7.0.4",
+        "husky": "8.0.1",
         "jest": "27.4.7",
         "lint-staged": "12.4.3",
         "node-mocks-http": "1.11.0",
@@ -4073,15 +4073,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -11206,9 +11206,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-jest": "26.5.3",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
-    "husky": "7.0.4",
+    "husky": "8.0.1",
     "jest": "27.4.7",
     "lint-staged": "12.4.3",
     "node-mocks-http": "1.11.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[husky](https://www.npmjs.com/package/husky)|devDependencies|major|[`7.0.4`](https://www.npmjs.com/package/husky/v/7.0.4)|[`8.0.1`](https://www.npmjs.com/package/husky/v/8.0.1)|

## Package diffs

- [GitHub](https://togithub.com/typicode/husky/compare/v7.0.4...v8.0.1)
- [npmfs](https://npmfs.com/compare/husky/7.0.4/8.0.1)
- [Package Diff](https://diff.intrinsic.com/husky/7.0.4/8.0.1)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/husky/7.0.4/8.0.1)

## Release notes

- [v7.0.4](https://togithub.com/typicode/husky/releases/tag/v7.0.4)
- [v8.0.0](https://togithub.com/typicode/husky/releases/tag/v8.0.0)
- [v8.0.1](https://togithub.com/typicode/husky/releases/tag/v8.0.1)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "1.2.26",
  "packages": [
    {
      "name": "husky",
      "currentVersion": "7.0.4",
      "newVersion": "8.0.1",
      "level": "major"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v1.2.26