### PR TITLE
chore(deps): major update @jest/types to v28.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "undici": "5.7.0"
       },
       "devDependencies": {
-        "@jest/types": "27.4.2",
+        "@jest/types": "28.1.3",
         "@tsconfig/node16": "1.0.3",
         "@types/jest": "27.4.1",
         "@types/node": "16.11.32",
@@ -1082,6 +1082,18 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
+      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.24.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
     "node_modules/@jest/source-map": {
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.4.0.tgz",
@@ -1202,19 +1214,29 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
-      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
+      "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
       "dev": true,
       "dependencies": {
+        "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/@types/yargs": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
+      "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1276,6 +1298,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.24.27",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
+      "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -8987,6 +9015,15 @@
         }
       }
     },
+    "@jest/schemas": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
+      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.24.1"
+      }
+    },
     "@jest/source-map": {
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.4.0.tgz",
@@ -9090,16 +9127,28 @@
       }
     },
     "@jest/types": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
-      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
+      "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
       "dev": true,
       "requires": {
+        "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/yargs": {
+          "version": "17.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
+          "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        }
       }
     },
     "@jridgewell/resolve-uri": {
@@ -9149,6 +9198,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@sinclair/typebox": {
+      "version": "0.24.27",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
+      "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "undici": "5.7.0"
   },
   "devDependencies": {
-    "@jest/types": "27.4.2",
+    "@jest/types": "28.1.3",
     "@tsconfig/node16": "1.0.3",
     "@types/jest": "27.4.1",
     "@types/node": "16.11.32",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[@jest/types](https://www.npmjs.com/package/@jest/types)|devDependencies|major|[`27.4.2`](https://www.npmjs.com/package/@jest/types/v/27.4.2)|[`28.1.3`](https://www.npmjs.com/package/@jest/types/v/28.1.3)|

## Package diffs

- [GitHub](https://togithub.com/facebook/jest/compare/v27.4.2...v28.1.3)
- [npmfs](https://npmfs.com/compare/@jest/types/27.4.2/28.1.3)
- [Package Diff](https://diff.intrinsic.com/@jest/types/27.4.2/28.1.3)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/@jest/types/27.4.2/28.1.3)

## Release notes

- [v27.4.2](https://togithub.com/facebook/jest/releases/tag/v27.4.2)
- [v27.5.0](https://togithub.com/facebook/jest/releases/tag/v27.5.0)
- [v27.5.1](https://togithub.com/facebook/jest/releases/tag/v27.5.1)
- [v28.0.0-alpha.0](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.0)
- [v28.0.0-alpha.1](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.1)
- [v28.0.0-alpha.2](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.2)
- [v28.0.0-alpha.3](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.3)
- [v28.0.0-alpha.4](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.4)
- [v28.0.0-alpha.5](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.5)
- [v28.0.0-alpha.6](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.6)
- [v28.0.0-alpha.7](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.7)
- [v28.0.0-alpha.8](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.8)
- [v28.0.0-alpha.9](https://togithub.com/facebook/jest/releases/tag/v28.0.0-alpha.9)
- [v28.0.0](https://togithub.com/facebook/jest/releases/tag/v28.0.0)
- [v28.0.1](https://togithub.com/facebook/jest/releases/tag/v28.0.1)
- [v28.0.2](https://togithub.com/facebook/jest/releases/tag/v28.0.2)
- [v28.1.0](https://togithub.com/facebook/jest/releases/tag/v28.1.0)
- [v28.1.1](https://togithub.com/facebook/jest/releases/tag/v28.1.1)
- [v28.1.3](https://togithub.com/facebook/jest/releases/tag/v28.1.3)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "1.3.6",
  "packages": [
    {
      "name": "@jest/types",
      "currentVersion": "27.4.2",
      "newVersion": "28.1.3",
      "level": "major"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v1.3.6