### PR TITLE
chore(deps): major update @types/node to v18.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@tsconfig/node16": "1.0.3",
-        "@types/node": "16.11.32",
+        "@types/node": "18.11.3",
         "@typescript-eslint/eslint-plugin": "5.4.0",
         "eslint": "8.3.0",
         "eslint-config-standard-with-typescript": "21.0.1",
@@ -1389,9 +1389,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
-      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA==",
+      "version": "18.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
+      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7904,9 +7904,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
-      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA==",
+      "version": "18.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
+      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@tsconfig/node16": "1.0.3",
-    "@types/node": "16.11.32",
+    "@types/node": "18.11.3",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",
     "eslint-config-standard-with-typescript": "21.0.1",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Version|
|---|---|---|---|
|[@types/node](https://www.npmjs.com/package/@types/node)|devDependencies|major|[`16.11.32`](https://www.npmjs.com/package/@types/node/v/16.11.32) -> [`18.11.3`](https://www.npmjs.com/package/@types/node/v/18.11.3) ([diff](https://renovatebot.com/diffs/npm/@types/node/16.11.32/18.11.3))|

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.45.16",
  "packages": [
    {
      "name": "@types/node",
      "currentVersion": "16.11.32",
      "newVersion": "18.11.3",
      "level": "major"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.45.16