### PR TITLE
chore(deps): patch update eslint-plugin-jest to v27.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint": "8.3.0",
         "eslint-config-standard-with-typescript": "21.0.1",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.1.2",
+        "eslint-plugin-jest": "27.1.3",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-promise": "5.2.0",
         "husky": "8.0.1",
@@ -2874,9 +2874,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.2.tgz",
-      "integrity": "sha512-+nLOn5jvQKLUywXxXKsLuuENsB/FhygXOLI+l5QlF+ACGe0DM14FlpYrGZ4nEiTo0BGlL5MymG73XA/tC3v3fA==",
+      "version": "27.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.3.tgz",
+      "integrity": "sha512-7DrIfYRQPa7JQd1Le8G/BJsfYHVUKQdJQ/6vULSp/4NjKZmSMJ/605G2hhScEra++SiH68zPEjLnrO74nHrMLg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -9017,9 +9017,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "27.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.2.tgz",
-      "integrity": "sha512-+nLOn5jvQKLUywXxXKsLuuENsB/FhygXOLI+l5QlF+ACGe0DM14FlpYrGZ4nEiTo0BGlL5MymG73XA/tC3v3fA==",
+      "version": "27.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.3.tgz",
+      "integrity": "sha512-7DrIfYRQPa7JQd1Le8G/BJsfYHVUKQdJQ/6vULSp/4NjKZmSMJ/605G2hhScEra++SiH68zPEjLnrO74nHrMLg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "8.3.0",
     "eslint-config-standard-with-typescript": "21.0.1",
     "eslint-plugin-import": "2.26.0",
-    "eslint-plugin-jest": "27.1.2",
+    "eslint-plugin-jest": "27.1.3",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
     "husky": "8.0.1",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Version|
|---|---|---|---|
|[eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest)|devDependencies|patch|[`27.1.2`](https://www.npmjs.com/package/eslint-plugin-jest/v/27.1.2) -> [`27.1.3`](https://www.npmjs.com/package/eslint-plugin-jest/v/27.1.3) ([diff](https://renovatebot.com/diffs/npm/eslint-plugin-jest/27.1.2/27.1.3))|

## Release notes

- [v27.1.2](https://togithub.com/jest-community/eslint-plugin-jest/releases/tag/v27.1.2)
- [v27.1.3](https://togithub.com/jest-community/eslint-plugin-jest/releases/tag/v27.1.3)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "0.45.16",
  "packages": [
    {
      "name": "eslint-plugin-jest",
      "currentVersion": "27.1.2",
      "newVersion": "27.1.3",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.45.16