### PR TITLE
chore(deps): patch update node-mocks-http to v1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-promise": "5.2.0",
         "husky": "8.0.3",
         "lint-staged": "13.1.2",
-        "node-mocks-http": "1.12.1",
+        "node-mocks-http": "1.12.2",
         "rimraf": "4.4.1",
         "ts-node": "10.9.1",
         "typescript": "5.0.4"
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/node-mocks-http": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.12.1.tgz",
-      "integrity": "sha512-jrA7Sn3qI6GsHgWtUW3gMj0vO6Yz0nJjzg3jRZYjcfj4tzi8oWPauDK1qHVJoAxTbwuDHF1JiM9GISZ/ocI/ig==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.12.2.tgz",
+      "integrity": "sha512-xhWwC0dh35R9rf0j3bRZXuISXdHxxtMx0ywZQBwjrg3yl7KpRETzogfeCamUIjltpn0Fxvs/ZhGJul1vPLrdJQ==",
       "dev": true,
       "dependencies": {
         "accepts": "^1.3.7",
@@ -5951,9 +5951,9 @@
       "dev": true
     },
     "node-mocks-http": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.12.1.tgz",
-      "integrity": "sha512-jrA7Sn3qI6GsHgWtUW3gMj0vO6Yz0nJjzg3jRZYjcfj4tzi8oWPauDK1qHVJoAxTbwuDHF1JiM9GISZ/ocI/ig==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.12.2.tgz",
+      "integrity": "sha512-xhWwC0dh35R9rf0j3bRZXuISXdHxxtMx0ywZQBwjrg3yl7KpRETzogfeCamUIjltpn0Fxvs/ZhGJul1vPLrdJQ==",
       "dev": true,
       "requires": {
         "accepts": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-promise": "5.2.0",
     "husky": "8.0.3",
     "lint-staged": "13.1.2",
-    "node-mocks-http": "1.12.1",
+    "node-mocks-http": "1.12.2",
     "rimraf": "4.4.1",
     "ts-node": "10.9.1",
     "typescript": "5.0.4"


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[node-mocks-http](https://www.npmjs.com/package/node-mocks-http)|devDependencies|patch|[`1.12.1`](https://www.npmjs.com/package/node-mocks-http/v/1.12.1)|[`1.12.2`](https://www.npmjs.com/package/node-mocks-http/v/1.12.2)|

## Package diffs

- [GitHub](https://togithub.com/howardabrams/node-mocks-http/compare/v1.12.1...v1.12.2)
- [npmfs](https://npmfs.com/compare/node-mocks-http/1.12.1/1.12.2)
- [Package Diff](https://diff.intrinsic.com/node-mocks-http/1.12.1/1.12.2)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/node-mocks-http/1.12.1/1.12.2)

## Release notes

- [v1.12.1](https://togithub.com/howardabrams/node-mocks-http/releases/tag/v1.12.1)
- [v1.12.2](https://togithub.com/howardabrams/node-mocks-http/releases/tag/v1.12.2)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "1.5.24",
  "packages": [
    {
      "name": "node-mocks-http",
      "currentVersion": "1.12.1",
      "newVersion": "1.12.2",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v1.5.24